### PR TITLE
fix: AzureFunction implements AutoCloseable

### DIFF
--- a/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
+++ b/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
@@ -16,7 +16,11 @@
 package io.micronaut.azure.function;
 
 import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.ApplicationContextProvider;
 import io.micronaut.context.env.Environment;
+
+import java.io.Closeable;
+import java.io.IOException;
 
 /**
  * A base Azure function class that sets up the Azure environment and preferred configuration.
@@ -24,7 +28,7 @@ import io.micronaut.context.env.Environment;
  * @author graemerocher
  * @since 1.0.0
  */
-public abstract class AzureFunction {
+public abstract class AzureFunction implements ApplicationContextProvider, Closeable {
     protected static ApplicationContext applicationContext;
 
     static {
@@ -40,6 +44,19 @@ public abstract class AzureFunction {
                 applicationContext = null;
             }
         }));
+    }
+
+    @Override
+    public ApplicationContext getApplicationContext() {
+        return this.applicationContext;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (applicationContext != null) {
+            applicationContext.close();
+            applicationContext = null;
+        }
     }
 
     /**

--- a/azure-function/src/test/groovy/io/micronaut/azure/function/AzureFunctionSpec.groovy
+++ b/azure-function/src/test/groovy/io/micronaut/azure/function/AzureFunctionSpec.groovy
@@ -1,0 +1,15 @@
+package io.micronaut.azure.function
+
+import spock.lang.Specification
+
+class AzureFunctionSpec extends Specification {
+
+    void "AzureFunction implements AutoCloseable"() {
+        expect:
+        new FooFunction() instanceof AutoCloseable
+    }
+
+    static class FooFunction extends AzureFunction {
+
+    }
+}


### PR DESCRIPTION
A Micronaut application with `azure-function-http` function generates a test such as: 

```java
package com.example;
import com.microsoft.azure.functions.HttpStatus;
import io.micronaut.azure.function.http.HttpRequestMessageBuilder;
import io.micronaut.http.HttpMethod;
import org.junit.jupiter.api.Test;
import static org.junit.jupiter.api.Assertions.assertEquals;

public class DemoFunctionTest {

    @Test
    public void testFunction() throws Exception {
        try (Function function = new Function()) {
            HttpRequestMessageBuilder.AzureHttpResponseMessage response =
                function.request(HttpMethod.GET, "/demo")
                        .invoke();

            assertEquals(HttpStatus.OK, response.getStatus());
        }
    }
}
```

`Function` is a class which extends from `AzureHttpFunction`.  `AzureHttpFunction`  extends from  `AzureFunction`. Since none implement` AutoCloseable`, the try with resources block does not compile. 

`AzureFunction` registers a `shutdownHook`. However, I think we should also implement both `Closeable` and `ApplicationContextProvider` for `AzureFunction`.