### PR TITLE
fix: check if application context is already null

### DIFF
--- a/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
+++ b/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
@@ -40,7 +40,9 @@ public abstract class AzureFunction implements ApplicationContextProvider, Close
         Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
             @Override
             public void run() {
-                applicationContext.close();
+                if (applicationContext != null) {
+                    applicationContext.close();
+                }
                 applicationContext = null;
             }
         }));


### PR DESCRIPTION
before closing it