### PR TITLE
Explicitly destroy this AzureHttpFunction

### DIFF
--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
@@ -109,7 +109,7 @@ public class AzureHttpFunction extends AzureFunction {
      *
      * @param request The request
      * @param executionContext The execution context
-     * @return THe response message
+     * @return The response message
      */
     public HttpResponseMessage route(
             HttpRequestMessage<Optional<String>> request,
@@ -128,7 +128,7 @@ public class AzureHttpFunction extends AzureFunction {
 
             return exchange.getResponse().getNativeResponse();
         } finally {
-            applicationContext.destroyBean(getClass());
+            applicationContext.destroyBean(this);
         }
     }
 


### PR DESCRIPTION
The stacktrace in https://github.com/micronaut-projects/micronaut-azure/issues/387 asks for this change.
Caused by: java.lang.IllegalArgumentException: Cannot destroy non-singleton bean using bean definition! Use 'destroyBean(BeanRegistration)ordestroyBean()`.

closes https://github.com/micronaut-projects/micronaut-azure/issues/387