### PR TITLE
Fix the build for 4.0.0

### DIFF
--- a/.github/workflows/graalvm.yml
+++ b/.github/workflows/graalvm.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         java: ['17']
-        graalvm: ['latest', 'dev']
+        graalvm: ['latest']
     steps:
        # https://github.com/actions/virtual-environments/issues/709
       - name: Free disk space

--- a/azure-function-http-test/src/test/groovy/io/micronaut/azure/function/http/test/AzureFunctionCorsSpec.groovy
+++ b/azure-function-http-test/src/test/groovy/io/micronaut/azure/function/http/test/AzureFunctionCorsSpec.groovy
@@ -39,25 +39,30 @@ class AzureFunctionCorsSpec extends Specification implements TestPropertyProvide
         headerNames.contains(SERVER)
     }
 
-    void "test cors request without configuration"() {
-        given:
-        HttpResponse<?> response = client.toBlocking().exchange(
+    void "test cors localhost driveby request without configuration"() {
+        when:
+        client.toBlocking().exchange(
                 HttpRequest.GET('/api/cors/test')
                         .header(ORIGIN, 'fooBar.com')
         )
+
+        then:
+        HttpClientResponseException e = thrown()
+        HttpResponse<?> response =  e.response
 
         when:
         Set<String> headerNames = response.headers.names()
 
         then:
-        response.status == HttpStatus.NO_CONTENT
+        response.status == HttpStatus.FORBIDDEN
         !headerNames.contains(ACCESS_CONTROL_MAX_AGE)
         !headerNames.contains(VARY)
         !headerNames.contains(ACCESS_CONTROL_ALLOW_METHODS)
         !headerNames.contains(ACCESS_CONTROL_ALLOW_HEADERS)
-        headerNames.size() == 2
+        headerNames.size() == 3
         headerNames.contains(DATE)
         headerNames.contains(SERVER)
+        headerNames.contains(CONTENT_LENGTH)
     }
 
     void "test cors request with a controller that returns map"() {

--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.functions.HttpRequestMessage;
 import com.microsoft.azure.functions.HttpResponseMessage;
 import io.micronaut.azure.function.AzureFunction;
 import io.micronaut.context.ApplicationContextBuilder;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.http.context.ServerContextPathProvider;
 import io.micronaut.servlet.http.ServletExchange;
@@ -71,7 +72,7 @@ public class AzureHttpFunction extends AzureFunction {
      */
     protected AzureHttpFunction(ApplicationContextBuilder applicationContextBuilder) {
         super(applicationContextBuilder);
-        httpHandler = new HttpHandler(getApplicationContext());
+        httpHandler = new HttpHandler(applicationContext, applicationContext.getBean(ConversionService.class));
         registerHttpHandlerShutDownHook();
         this.contextPath = applicationContext.findBean(ServerContextPathProvider.class).map(ServerContextPathProvider::getContextPath).orElse("/api");
     }

--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
@@ -72,7 +72,7 @@ public class AzureHttpFunction extends AzureFunction {
      */
     protected AzureHttpFunction(ApplicationContextBuilder applicationContextBuilder) {
         super(applicationContextBuilder);
-        httpHandler = new HttpHandler(applicationContext, applicationContext.getBean(ConversionService.class));
+        httpHandler = new HttpHandler(applicationContext);
         registerHttpHandlerShutDownHook();
         this.contextPath = applicationContext.findBean(ServerContextPathProvider.class).map(ServerContextPathProvider::getContextPath).orElse("/api");
     }

--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/HttpHandler.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/HttpHandler.java
@@ -34,8 +34,8 @@ import java.util.Optional;
 @Internal
 public class HttpHandler extends ServletHttpHandler<HttpRequestMessage<Optional<String>>, HttpResponseMessage> {
 
-    public HttpHandler(ApplicationContext applicationContext, ConversionService conversionService) {
-        super(init(applicationContext), conversionService);
+    public HttpHandler(ApplicationContext applicationContext) {
+        super(init(applicationContext), applicationContext.getBean(ConversionService.class));
     }
 
     private static ApplicationContext init(ApplicationContext applicationContext) {

--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/HttpHandler.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/HttpHandler.java
@@ -19,6 +19,7 @@ import com.microsoft.azure.functions.HttpRequestMessage;
 import com.microsoft.azure.functions.HttpResponseMessage;
 import io.micronaut.context.ApplicationContext;
 import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.convert.ConversionService;
 import io.micronaut.servlet.http.ServletExchange;
 import io.micronaut.servlet.http.ServletHttpHandler;
 import io.netty.util.internal.MacAddressUtil;
@@ -32,8 +33,9 @@ import java.util.Optional;
  */
 @Internal
 public class HttpHandler extends ServletHttpHandler<HttpRequestMessage<Optional<String>>, HttpResponseMessage> {
-    public HttpHandler(ApplicationContext applicationContext) {
-        super(init(applicationContext));
+
+    public HttpHandler(ApplicationContext applicationContext, ConversionService conversionService) {
+        super(init(applicationContext), conversionService);
     }
 
     private static ApplicationContext init(ApplicationContext applicationContext) {


### PR DESCRIPTION
Servlet now requires a ConversionContext

Cors driveby attack is now blocked so we need to fix the test to replicate this.