### PR TITLE
Fix MissingBodyAnnotationTest

### DIFF
--- a/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/AzureFunctionHttpServerUnderTest.java
+++ b/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/AzureFunctionHttpServerUnderTest.java
@@ -19,6 +19,7 @@ import io.micronaut.http.MutableHttpResponse;
 import io.micronaut.http.client.exceptions.HttpClientResponseException;
 import io.micronaut.http.simple.SimpleHttpResponseFactory;
 import io.micronaut.http.tck.ServerUnderTest;
+import io.micronaut.json.JsonMapper;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -74,9 +75,13 @@ public class AzureFunctionHttpServerUnderTest implements ServerUnderTest {
             if (body.isPresent()) {
                 return Optional.of(getDataString(body.get()));
             }
-            return request.getBody(String.class);
         }
-        return request.getBody(String.class);
+        return BodyUtils.bodyAsString(
+            getApplicationContext().getBean(JsonMapper.class),
+            () -> request.getContentType().orElse(null),
+            request::getCharacterEncoding,
+            () -> request.getBody().orElse(null)
+        );
     }
 
     private <O> HttpResponse<O> adaptResponse(HttpResponseMessage azureResponse) {

--- a/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/BodyUtils.java
+++ b/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/BodyUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017-2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.http.server.tck.azurehttpfunction;
+
+import io.micronaut.core.annotation.Internal;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.http.MediaType;
+import io.micronaut.json.JsonMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Utility class to provide conversion for HTTP request body.
+ * @author Sergio del Amo
+ * @since 4.0.0
+ */
+@Internal
+public final class BodyUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BodyUtils.class);
+
+    private BodyUtils() {
+    }
+
+    @NonNull
+    public static Optional<String> bodyAsString(@NonNull JsonMapper jsonMapper,
+                                  @NonNull Supplier<MediaType> contentTypeSupplier,
+                                  @NonNull Supplier<Charset> characterEncodingSupplier ,
+                                  @NonNull Supplier<Object> bodySupplier) {
+        Object body = bodySupplier.get();
+        MediaType mediaType = contentTypeSupplier.get();
+        boolean mapFromJson = mediaType == null || mediaType.equals(MediaType.APPLICATION_JSON_TYPE);
+        if (body instanceof CharSequence) {
+            return Optional.of(body.toString());
+        } else if (body instanceof byte[] bytes) {
+            return Optional.of(new String(bytes, characterEncodingSupplier.get()));
+        } else if (mapFromJson) {
+            try {
+                return Optional.of(jsonMapper.writeValueAsString(body));
+            } catch (IOException e) {
+                LOG.error("IOException writing body to JSON String", e);
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
@@ -25,7 +25,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 
     "io.micronaut.http.server.tck.tests.HeadersTest", // headersAreCaseInsensitiveAsPerMessageHeadersSpecification
     "io.micronaut.http.server.tck.tests.StreamTest",
-    "io.micronaut.http.server.tck.tests.MissingBodyAnnotationTest",
     "io.micronaut.http.server.tck.tests.constraintshandler.ControllerConstraintHandlerTest" // Broken in servlet
 })
 public class AzureFunctionHttpHttpServerTestSuite {


### PR DESCRIPTION
The test in MissingBodyAnnotationTest has a request with a POJO as a body and no content type.

When converting this to a Azure Request prior to this PR we were simply calling toString() on the POJO, which resulted in an invalid body in the request.

This PR attempts to convert the body to a usable form instead.

Only the tests are affected