### PR TITLE
bug: close application context

### DIFF
--- a/azure-function-http-test/src/main/java/io/micronaut/azure/function/http/test/AzureFunctionEmbeddedServer.java
+++ b/azure-function-http-test/src/main/java/io/micronaut/azure/function/http/test/AzureFunctionEmbeddedServer.java
@@ -149,6 +149,7 @@ final class AzureFunctionEmbeddedServer implements EmbeddedServer {
     public EmbeddedServer stop() {
         if (running.compareAndSet(true, false)) {
             try {
+                applicationContext.stop();
                 server.stop();
             } catch (Exception e) {
                 // ignore / unrecoverable


### PR DESCRIPTION
This avoid too many open files errors when running the TCK in MacOS.