### PR TITLE
Try to make CosmosClientSpec more stable on MacOS

### DIFF
--- a/azure-cosmos/src/test/groovy/io/micronaut/azure/cosmos/client/AzureCosmosTestProperties.groovy
+++ b/azure-cosmos/src/test/groovy/io/micronaut/azure/cosmos/client/AzureCosmosTestProperties.groovy
@@ -7,14 +7,21 @@ import org.testcontainers.utility.DockerImageName
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.KeyStore
+import java.time.Duration
 
 trait AzureCosmosTestProperties implements TestPropertyProvider {
+
+    private static final String PARTITION_COUNT_PROP = "AZURE_COSMOS_EMULATOR_PARTITION_COUNT"
+    // This will create 2 partitions, by default it creates 11 and we don't need that much
+    // and it prolongs startup time which can cause test to fail intermittently
+    private static final String PARTITION_COUNT_VAL = "1"
+    private static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(3)
 
     @Override
     Map<String, String> getProperties() {
         CosmosDBEmulatorContainer emulator = new CosmosDBEmulatorContainer(
-                DockerImageName.parse("mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest")
-        )
+                DockerImageName.parse("mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator")
+        ).withEnv(PARTITION_COUNT_PROP, PARTITION_COUNT_VAL).withStartupTimeout(STARTUP_TIMEOUT)
         emulator.start()
         Path keyStoreFile = Files.createTempFile("azure-cosmos-emulator", ".keystore")
         KeyStore keyStore = emulator.buildNewKeyStore()

--- a/azure-cosmos/src/test/groovy/io/micronaut/azure/cosmos/client/CosmosClientSpec.groovy
+++ b/azure-cosmos/src/test/groovy/io/micronaut/azure/cosmos/client/CosmosClientSpec.groovy
@@ -19,7 +19,7 @@ import spock.lang.Shared
 import spock.lang.Specification
 
 @Requires({ DockerClientFactory.instance().isDockerAvailable() })
-@IgnoreIf({ env["GITHUB_WORKFLOW"] })
+@IgnoreIf(value = { env["GITHUB_WORKFLOW"] }, reason = "https://github.com/Azure/azure-cosmos-db-emulator-docker/issues/56")
 class CosmosClientSpec extends Specification implements AzureCosmosTestProperties {
 
     @AutoCleanup


### PR DESCRIPTION
@sdelamo I noticed similar for micronaut-data and increased startup timeout. Still not 100% stable but works better. 
Tested this on Apple M2 Max chip. 
Reduced number of partitions for the emulator and set startup timeout to 3 minutes 🤷 as I don't think we have better options. 