### PR TITLE
fix issue with dropping query parameters from request URIs

### DIFF
--- a/azure-function-http-test/src/main/java/io/micronaut/azure/function/http/test/AzureFunctionEmbeddedServer.java
+++ b/azure-function-http-test/src/main/java/io/micronaut/azure/function/http/test/AzureFunctionEmbeddedServer.java
@@ -235,7 +235,7 @@ final class AzureFunctionEmbeddedServer implements EmbeddedServer {
         public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException {
             HttpRequestMessageBuilder<Object> requestMessageBuilder = HttpRequestMessageBuilder.builder(
                     com.microsoft.azure.functions.HttpMethod.value(request.getMethod()),
-                    request.getRequestURI(),
+                    baseRequest.getOriginalURI(),
                     httpHandler.getApplicationContext()
             );
 

--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureFunctionHttpRequest.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureFunctionHttpRequest.java
@@ -110,7 +110,7 @@ public final class AzureFunctionHttpRequest<T> implements
         this.binaryContentConfiguration = binaryContentConfiguration;
         this.requestEvent = request;
         this.response = response;
-        this.uri = URI.create(requestEvent.getUri().getPath());
+        this.uri = requestEvent.getUri();
         this.httpMethod = parseMethod(requestEvent.getHttpMethod()::name);
         this.body = SupplierUtil.memoizedNonEmpty(() -> {
             T built = parsedBody != null ? parsedBody :  (T) bodyBuilder.buildBody(this::getInputStream, this);

--- a/test-suite-http-server-tck-azure-function-http-test/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpTestHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-azure-function-http-test/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpTestHttpServerTestSuite.java
@@ -7,8 +7,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @ExcludeClassNamePatterns({
-        "io.micronaut.http.server.tck.tests.RequestUriContainsQueryValueTest",
-        "io.micronaut.http.server.tck.tests.RequestUriTest",
         "io.micronaut.http.server.tck.tests.FilterProxyTest",
         "io.micronaut.http.server.tck.tests.HeadersTest"
 })

--- a/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
@@ -7,8 +7,6 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @ExcludeClassNamePatterns({
-        "io.micronaut.http.server.tck.tests.RequestUriContainsQueryValueTest",
-        "io.micronaut.http.server.tck.tests.RequestUriTest",
         "io.micronaut.http.server.tck.tests.FilterProxyTest",
         "io.micronaut.http.server.tck.tests.HeadersTest"
 })


### PR DESCRIPTION
partial fix for #577

- [x]  io.micronaut.http.server.tck.tests.RequestUriContainsQueryValueTest
- [x]  io.micronaut.http.server.tck.tests.RequestUriTest