### PR TITLE
Handle multi-value header correctly in TCK

### DIFF
--- a/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
@@ -1,8 +1,6 @@
 package io.micronaut.http.server.tck.azurehttpfunction.tests;
 
-import io.micronaut.http.server.tck.tests.HeadersTest;
 import org.junit.platform.suite.api.ExcludeClassNamePatterns;
-import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;

--- a/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
@@ -1,14 +1,15 @@
 package io.micronaut.http.server.tck.azurehttpfunction.tests;
 
+import io.micronaut.http.server.tck.tests.HeadersTest;
 import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.SelectClasses;
 import org.junit.platform.suite.api.SelectPackages;
 import org.junit.platform.suite.api.Suite;
 import org.junit.platform.suite.api.SuiteDisplayName;
 
 @Suite
 @ExcludeClassNamePatterns({
-        "io.micronaut.http.server.tck.tests.FilterProxyTest",
-        "io.micronaut.http.server.tck.tests.HeadersTest"
+        "io.micronaut.http.server.tck.tests.FilterProxyTest"
 })
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Azure Functions")


### PR DESCRIPTION
`AzureRequestEventFactory` is updated to correctly handle multi-valued headers, and `HeadersTest` is enabled.

This at least partially fixes the TCK. The suit in `test-suite-http-server-tck-azure-function-http-test` still fails. 
It uses the `AzureFunctionEmbeddedServer` by way of `EmbeddedServerUnderTestProvider`, thus the request and headers are
being constructed in `DefaultHttpRequestMessageBuilder`. I believe `DefaultHttpRequestMessageBuilder` needs to also be 
updated to correctly handle multi-valued headers.