### PR TITLE
Fix concurrent calls for Azure Functions

### DIFF
--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
@@ -76,6 +76,7 @@ public class AzureHttpFunction extends AzureFunction {
         }
         httpHandler = new HttpHandler(getApplicationContext());
         registerHttpHandlerShutDownHook();
+        getApplicationContext().registerSingleton(this);
     }
 
     /**

--- a/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
+++ b/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
@@ -35,7 +35,7 @@ import java.io.Closeable;
 public abstract class AzureFunction implements ApplicationContextProvider, Closeable {
 
     protected static final Logger LOG = LoggerFactory.getLogger(AzureFunction.class);
-    protected static ApplicationContext applicationContext;
+    protected ApplicationContext applicationContext;
 
     /**
      * Default constructor.
@@ -53,9 +53,7 @@ public abstract class AzureFunction implements ApplicationContextProvider, Close
             LOG.trace("Initializing Azure function");
         }
         try {
-            if (applicationContext == null) {
-                startApplicationContext(applicationContextBuilder);
-            }
+            startApplicationContext(applicationContextBuilder);
         } catch (Throwable  e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Error initializing Azure function: " + e.getMessage(), e);
@@ -92,7 +90,7 @@ public abstract class AzureFunction implements ApplicationContextProvider, Close
         }
     }
 
-    public static void startApplicationContext(ApplicationContextBuilder applicationContextBuilder) {
+    public void startApplicationContext(ApplicationContextBuilder applicationContextBuilder) {
         if (applicationContext == null) {
             applicationContext = (applicationContextBuilder != null ? applicationContextBuilder : defaultApplicationContextBuilder()).build();
             applicationContext.start();

--- a/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
+++ b/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2024 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-import java.io.IOException;
 
 /**
  * A base Azure function class that sets up the Azure environment and preferred configuration.
@@ -50,8 +49,13 @@ public abstract class AzureFunction implements ApplicationContextProvider, Close
      * @param applicationContextBuilder ApplicationContext Builder;
      */
     protected AzureFunction(ApplicationContextBuilder applicationContextBuilder) {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Initializing Azure function");
+        }
         try {
-            startApplicationContext(applicationContextBuilder);
+            if (applicationContext == null) {
+                startApplicationContext(applicationContextBuilder);
+            }
         } catch (Throwable  e) {
             if (LOG.isErrorEnabled()) {
                 LOG.error("Error initializing Azure function: " + e.getMessage(), e);
@@ -75,11 +79,13 @@ public abstract class AzureFunction implements ApplicationContextProvider, Close
 
     @Override
     public ApplicationContext getApplicationContext() {
+        LOG.trace("getApplicationContext() called. Returning: {}", applicationContext);
         return applicationContext;
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
+        LOG.trace("Closing Azure Function");
         if (applicationContext != null) {
             applicationContext.close();
             applicationContext = null;
@@ -87,8 +93,10 @@ public abstract class AzureFunction implements ApplicationContextProvider, Close
     }
 
     public static void startApplicationContext(ApplicationContextBuilder applicationContextBuilder) {
-        applicationContext = (applicationContextBuilder != null ? applicationContextBuilder : defaultApplicationContextBuilder()).build();
-        applicationContext.start();
+        if (applicationContext == null) {
+            applicationContext = (applicationContextBuilder != null ? applicationContextBuilder : defaultApplicationContextBuilder()).build();
+            applicationContext.start();
+        }
     }
 
     /**
@@ -103,11 +111,6 @@ public abstract class AzureFunction implements ApplicationContextProvider, Close
      * @return A new Thread which closes and sets to null the application context if not null
      */
     private Thread createApplicationContextShutDownHook() {
-        return new Thread(() -> {
-            if (applicationContext != null) {
-                applicationContext.close();
-            }
-            applicationContext = null;
-        });
+        return new Thread(this::close);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,3 +6,11 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+if (System.getenv("SONAR_TOKEN") != null) {
+    sonarqube {
+        properties {
+            property "sonar.exclusions", "**/example/**"
+        }
+    }
+}

--- a/config/accepted-api-changes.json
+++ b/config/accepted-api-changes.json
@@ -138,5 +138,10 @@
     "type": "io.micronaut.azure.function.http.$BinaryContentConfiguration$Definition$Reference",
     "member": "Implemented interface io.micronaut.inject.BeanDefinitionReference",
     "reason": "Removed BinaryContentConfiguration to use BinaryTypeConfiguration from core"
+  },
+  {
+    "type": "io.micronaut.azure.function.AzureFunction",
+    "member": "Field applicationContext",
+    "reason": "Application context was changed from a static to fix a concurrency issue #611"
   }
 ]

--- a/doc-examples/example-groovy/build.gradle.kts
+++ b/doc-examples/example-groovy/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 micronaut {
-    version("4.0.0-M2")
+    version(libs.versions.micronaut.platform.get())
 }
 
 dependencies {

--- a/doc-examples/example-java/build.gradle.kts
+++ b/doc-examples/example-java/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 micronaut {
-    version("4.0.0-M2")
+    version(libs.versions.micronaut.platform.get())
 }
 
 dependencies {

--- a/doc-examples/example-kotlin/build.gradle.kts
+++ b/doc-examples/example-kotlin/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.kapt)
 }
+
 dependencies {
     testImplementation(projects.micronautAzureFunctionHttp)
     testImplementation(libs.managed.azure.functions.java.library)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 managed-azure-sdk = "1.2.21"
 managed-azure-functions-java-library = "3.1.0"
 managed-azure-cosmos = "4.56.0"
+azurefunctions-plugin = "1.15.0"
 
 jakarta-inject-api = "2.0.1"
 kotlin = "1.9.22"
@@ -9,6 +10,7 @@ system-lambda = "1.2.1"
 
 # Micronaut
 micronaut = "4.3.9"
+micronaut-platform = "4.3.5"
 micronaut-logging = "1.1.2"
 micronaut-reactor = "3.2.1"
 micronaut-serde = "2.8.1"
@@ -26,6 +28,7 @@ spock = "2.3-groovy-4.0"
 [libraries]
 # Core
 micronaut-core = { module = 'io.micronaut:micronaut-core-bom', version.ref = 'micronaut' }
+micronaut-platform = { module = 'io.micronaut.platform:micronaut-platform', version.ref = 'micronaut-platform' }
 
 boms-azure-sdk = { module = "com.azure:azure-sdk-bom", version.ref = "managed-azure-sdk" }
 
@@ -60,3 +63,4 @@ testcontainers-azure = { module = "org.testcontainers:azure"}
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+azurefunctions-plugin = { id = "com.microsoft.azure.azurefunctions", version.ref = "azurefunctions-plugin"}

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ include 'doc-examples:example-java'
 include 'doc-examples:example-groovy'
 include 'doc-examples:example-kotlin'
 include("test-suite-azure-function-http-context-path")
+include("test-suite-dockerised")
 include("test-suite-http-server-tck-azure-function-http")
 include("test-suite-http-server-tck-azure-function-http-test")
 

--- a/test-suite-dockerised/build.gradle.kts
+++ b/test-suite-dockerised/build.gradle.kts
@@ -1,0 +1,54 @@
+plugins {
+    groovy
+    id("io.micronaut.build.internal.azure-example")
+    id("com.microsoft.azure.azurefunctions") version "1.15.0"
+}
+
+version = "1.0"
+
+micronaut {
+    version("4.3.5")
+    runtime("azure_function")
+    testRuntime("spock")
+}
+
+dependencies {
+    annotationProcessor(mn.micronaut.inject.java)
+    annotationProcessor(mnSerde.micronaut.serde.processor)
+
+//    implementation("io.micronaut.azure:micronaut-azure-function-http")
+    implementation(projects.micronautAzureFunctionHttp)
+    implementation(mnSerde.micronaut.serde.jackson)
+    implementation(libs.managed.azure.functions.java.library)
+
+    testImplementation(mnTestResources.testcontainers.core)
+    testImplementation(libs.jakarta.inject.api)
+
+    runtimeOnly(mnLogging.logback.classic)
+}
+
+azurefunctions {
+    resourceGroup = "java-functions-group"
+    appName = "test-suite"
+    pricingTier = "Consumption"
+    region = "westus"
+    setRuntime(closureOf<com.microsoft.azure.gradle.configuration.GradleRuntimeConfig> {
+        os("linux")
+        javaVersion("Java 17")
+    })
+}
+
+configurations.all {
+    resolutionStrategy.preferProjectModules()
+}
+
+tasks {
+    // We need the jar file for projects.micronautAzureFunctionHttp
+    val functionPackage = named("azureFunctionsPackage") {
+        dependsOn(rootProject.getTasksByName("publishAllPublicationsToBuildRepository", true))
+    }
+
+    named("test") {
+        dependsOn(functionPackage)
+    }
+}

--- a/test-suite-dockerised/build.gradle.kts
+++ b/test-suite-dockerised/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
     groovy
     id("io.micronaut.build.internal.azure-example")
-    id("com.microsoft.azure.azurefunctions") version "1.15.0"
+    alias(libs.plugins.azurefunctions.plugin)
 }
 
 version = "1.0"
 
 micronaut {
-    version("4.3.5")
+    version(libs.versions.micronaut.platform.get())
     runtime("azure_function")
     testRuntime("spock")
 }

--- a/test-suite-dockerised/build.gradle.kts
+++ b/test-suite-dockerised/build.gradle.kts
@@ -16,7 +16,6 @@ dependencies {
     annotationProcessor(mn.micronaut.inject.java)
     annotationProcessor(mnSerde.micronaut.serde.processor)
 
-//    implementation("io.micronaut.azure:micronaut-azure-function-http")
     implementation(projects.micronautAzureFunctionHttp)
     implementation(mnSerde.micronaut.serde.jackson)
     implementation(libs.managed.azure.functions.java.library)

--- a/test-suite-dockerised/host.json
+++ b/test-suite-dockerised/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "http": {
+      "routePrefix": ""
+    }
+  }
+}

--- a/test-suite-dockerised/local.settings.json
+++ b/test-suite-dockerised/local.settings.json
@@ -1,0 +1,21 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "",
+    "FUNCTIONS_WORKER_RUNTIME": "java",
+    "CosmosDBDatabaseName": "",
+    "CosmosDBCollectionName": "",
+    "AzureWebJobsCosmosDBConnectionString": "",
+    "AzureWebJobsEventGridOutputBindingTopicUriString": "",
+    "AzureWebJobsEventGridOutputBindingTopicKeyString": "",
+    "AzureWebJobsEventHubSender": "",
+    "AzureWebJobsEventHubSender_2": "",
+    "BrokerList": "",
+    "ConfluentCloudUsername": "",
+    "ConfluentCloudPassword": "",
+    "AzureWebJobsServiceBus": "",
+    "SBTopicName": "",
+    "SBTopicSubName": "",
+    "SBQueueName": ""
+  }
+}

--- a/test-suite-dockerised/src/main/java/example/micronaut/DefaultController.java
+++ b/test-suite-dockerised/src/main/java/example/micronaut/DefaultController.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+
+import io.micronaut.http.annotation.*;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.MediaType;
+import io.micronaut.serde.annotation.Serdeable;
+
+@Controller("/default")
+public class DefaultController {
+
+    @Produces(MediaType.TEXT_PLAIN)
+    @Get
+    public String index() {
+        return "Example Response";
+    }
+
+    @Post
+    public SampleReturnMessage postMethod(@Body SampleInputMessage inputMessage){
+      SampleReturnMessage retMessage = new SampleReturnMessage();
+      retMessage.setReturnMessage("Hello " + inputMessage.getName() + ", thank you for sending the message");
+      return retMessage;
+    }
+}
+
+@Serdeable
+class SampleInputMessage{
+    private String name;
+
+    public SampleInputMessage() {
+    }
+
+    public SampleInputMessage(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+    public void setName(String name) {
+        this.name = name;
+    }
+}
+
+@Serdeable
+class SampleReturnMessage{
+    private String returnMessage;
+    public String getReturnMessage() {
+        return returnMessage;
+    }
+    public void setReturnMessage(String returnMessage) {
+        this.returnMessage = returnMessage;
+    }
+}

--- a/test-suite-dockerised/src/main/java/example/micronaut/Function.java
+++ b/test-suite-dockerised/src/main/java/example/micronaut/Function.java
@@ -14,10 +14,17 @@
  * limitations under the License.
  */
 package example.micronaut;
-import java.util.*;
-import com.microsoft.azure.functions.annotation.*;
-import com.microsoft.azure.functions.*;
+
+import com.microsoft.azure.functions.ExecutionContext;
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
 import io.micronaut.azure.function.http.AzureHttpFunction;
+
+import java.util.Optional;
 
 /**
  * Azure Functions with HTTP Trigger.

--- a/test-suite-dockerised/src/main/java/example/micronaut/Function.java
+++ b/test-suite-dockerised/src/main/java/example/micronaut/Function.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-2024 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package example.micronaut;
+import java.util.*;
+import com.microsoft.azure.functions.annotation.*;
+import com.microsoft.azure.functions.*;
+import io.micronaut.azure.function.http.AzureHttpFunction;
+
+/**
+ * Azure Functions with HTTP Trigger.
+ */
+public class Function extends AzureHttpFunction {
+    /**
+     * This function listens at endpoint "/api/*". Two ways to invoke it using "curl" command in bash:
+     * 1. curl -d "HTTP Body" {your host}/api/*&code={your function key}
+     * 2. curl "{your host}/api/*?name=HTTP%20Query&code={your function key}"
+     * Function Key is not needed when running locally, it is used to invoke function deployed to Azure.
+     * More details: https://aka.ms/functions_authorization_keys
+     */
+    @FunctionName("ExampleTrigger")
+    public HttpResponseMessage invoke(
+            @HttpTrigger(
+                name = "req",
+                methods = {HttpMethod.GET, HttpMethod.POST},
+                route = "{*route}",
+                authLevel = AuthorizationLevel.ANONYMOUS)
+                HttpRequestMessage<Optional<String>> request,
+                final ExecutionContext context) {
+        return super.route(request, context);
+    }
+}

--- a/test-suite-dockerised/src/main/resources/logback.xml
+++ b/test-suite-dockerised/src/main/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>false</withJansi>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="off">
+        <appender-ref ref="STDOUT" />
+    </root>
+    <logger name="io.micronaut.azure" level="trace" />
+</configuration>

--- a/test-suite-dockerised/src/test/groovy/example/micronaut/ConcurrentFunctionSpec.groovy
+++ b/test-suite-dockerised/src/test/groovy/example/micronaut/ConcurrentFunctionSpec.groovy
@@ -1,0 +1,71 @@
+package example.micronaut
+
+import io.micronaut.context.ApplicationContext
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.MountableFile
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+
+@Issue("https://github.com/micronaut-projects/micronaut-azure/issues/611")
+class ConcurrentFunctionSpec extends Specification {
+
+    private static final int NUMBER_OF_THREADS = 3
+    private static final int NUMBER_OF_REQUESTS = 100
+
+    @Shared
+    @AutoCleanup
+    GenericContainer azureFunctionContainer = new GenericContainer("mcr.microsoft.com/azure-functions/java:4-java17")
+            .withEnv("AzureWebJobsScriptRoot", "/home/site/wwwroot")
+            .withEnv("AzureFunctionsJobHost__Logging__Console__IsEnabled", "true")
+            .withExposedPorts(80)
+            .waitingFor(Wait.forLogMessage(".*Host lock lease acquired by instance ID.*", 1))
+
+    def setupSpec() {
+        azureFunctionContainer
+                .tap { copyDirectory(it, new File("build/azure-functions/test-suite"), "/home/site/wwwroot") }
+                .start()
+    }
+
+    def "should work"() {
+        when:
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:${azureFunctionContainer.getMappedPort(80)}/default"))
+                .POST(HttpRequest.BodyPublishers.ofString('{"name":"Fred"}'))
+                .build()
+
+        AtomicInteger failures = new AtomicInteger()
+
+        then:
+        (1..NUMBER_OF_THREADS).collect {
+            Thread.start {
+                (1..NUMBER_OF_REQUESTS).each {
+                    def response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
+                    if (response.statusCode() != 200) {
+                        failures.incrementAndGet()
+                    }
+                }
+            }
+        }*.join()
+
+        failures.get() == 0
+    }
+
+    void copyDirectory(GenericContainer container, File dir, String root) {
+        println("Copying directory: ${dir.canonicalPath} to $root")
+        dir.traverse { file ->
+            if (file.isFile()) {
+                println("Copying file: $file to $root${file.path.substring(dir.path.size())}")
+                container.withCopyFileToContainer(MountableFile.forHostPath(file.canonicalPath), root + file.path.substring(dir.path.size()))
+            }
+        }
+    }
+}

--- a/test-suite-dockerised/src/test/groovy/example/micronaut/ConcurrentFunctionSpec.groovy
+++ b/test-suite-dockerised/src/test/groovy/example/micronaut/ConcurrentFunctionSpec.groovy
@@ -7,6 +7,7 @@ import spock.lang.AutoCleanup
 import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
+import spock.util.environment.Jvm
 
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -16,12 +17,13 @@ import java.util.concurrent.atomic.AtomicInteger
 @Issue("https://github.com/micronaut-projects/micronaut-azure/issues/611")
 class ConcurrentFunctionSpec extends Specification {
 
+    private static final String DOCKER_IMAGE_NAME = "mcr.microsoft.com/azure-functions/java:4-java${Jvm.current.javaSpecificationVersion}"
     private static final int NUMBER_OF_THREADS = 3
     private static final int NUMBER_OF_REQUESTS = 100
 
     @Shared
     @AutoCleanup
-    GenericContainer azureFunctionContainer = new GenericContainer("mcr.microsoft.com/azure-functions/java:4-java17")
+    GenericContainer azureFunctionContainer = new GenericContainer(DOCKER_IMAGE_NAME)
             .withEnv("AzureWebJobsScriptRoot", "/home/site/wwwroot")
             .withEnv("AzureFunctionsJobHost__Logging__Console__IsEnabled", "true")
             .withLogConsumer { log -> print("${log.getUtf8String()}") }
@@ -59,7 +61,7 @@ class ConcurrentFunctionSpec extends Specification {
     }
 
     void copyDirectory(GenericContainer container, File dir, String root) {
-        println("Copying directory: ${dir.canonicalPath} to $root")
+        println("Copying directory: ${dir.canonicalPath} to ${DOCKER_IMAGE_NAME}:$root")
         dir.traverse { file ->
             if (file.isFile()) {
                 println("Copying file: $file to $root${file.path.substring(dir.path.size())}")


### PR DESCRIPTION
When we migrated to use the Servlet core API (for Micronaut 4) we made mistakes when converting the old static code in [AzureFunction](https://github.com/micronaut-projects/micronaut-azure/blob/4.2.x/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java#L37-L58) and [HttpAzureFunction](https://github.com/micronaut-projects/micronaut-azure/blob/4.2.x/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java#L61-L95)

What we did worked for all the tests, but it causes issues when deployed to Azure infrastructure.

I believe this fixes that by making applicationContext non-static, and deferring to the super-class where appropriate.

I have also added a test which runs the function inside a Microsoft Azure function runner container, and hits it concurrently, so we don't have this issue again...

It is a breaking change, as making the `applicationContext` field non-static is non-binary compatible... But it's quite a serious bug, so I beleive breakage is appropriate.

Fixes #611 