### PR TITLE
Fix: Prevent global context reset per Azure Function invocation

### DIFF
--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
@@ -23,6 +23,7 @@ import io.micronaut.azure.function.AzureFunction;
 import io.micronaut.context.ApplicationContextBuilder;
 import io.micronaut.core.convert.ConversionService;
 import io.micronaut.function.BinaryTypeConfiguration;
+import io.micronaut.http.HttpHeaders;
 import io.micronaut.servlet.http.BodyBuilder;
 import io.micronaut.servlet.http.ServletExchange;
 import io.micronaut.servlet.http.ServletHttpHandler;
@@ -77,8 +78,8 @@ public class AzureHttpFunction extends AzureFunction {
         httpHandler = new HttpHandler(getApplicationContext());
         registerHttpHandlerShutDownHook();
 
-        if(!getApplicationContext().containsBean(this.getClass())) {
-            getApplicationContext().registerSingleton(this);
+        if (!getApplicationContext().containsBean(AzureHttpFunction.class)) {
+            getApplicationContext().registerSingleton(AzureHttpFunction.class, this);
         }
     }
 

--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
@@ -115,6 +115,8 @@ public class AzureHttpFunction extends AzureFunction {
             ServletExchange<HttpRequestMessage<Optional<String>>, HttpResponseMessage> exchange =
                 httpHandler.exchange(azureFunctionHttpRequest);
 
+            this.updateResponseHeadersFunction(exchange);
+
             return exchange.getResponse().getNativeResponse();
         } finally {
             if (LOG.isTraceEnabled()) {
@@ -148,5 +150,16 @@ public class AzureHttpFunction extends AzureFunction {
 
     private void registerHttpHandlerShutDownHook() {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> httpHandler = null));
+    }
+
+    /**
+     * Updates the headers of the response. Only necessary headers that do not conflict with Azure Function HTTP Trigger should be retained.
+     *
+     * @param exchange The exchange containing the response.
+     */
+    private void updateResponseHeadersFunction(ServletExchange<HttpRequestMessage<Optional<String>>, HttpResponseMessage> exchange) {
+        if (exchange.getResponse().getHeaders().contains(HttpHeaders.TRANSFER_ENCODING)) {
+            exchange.getResponse().getHeaders().remove(HttpHeaders.TRANSFER_ENCODING);
+        }
     }
 }

--- a/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
+++ b/azure-function-http/src/main/java/io/micronaut/azure/function/http/AzureHttpFunction.java
@@ -76,7 +76,10 @@ public class AzureHttpFunction extends AzureFunction {
         }
         httpHandler = new HttpHandler(getApplicationContext());
         registerHttpHandlerShutDownHook();
-        getApplicationContext().registerSingleton(this);
+
+        if(!getApplicationContext().containsBean(this.getClass())) {
+            getApplicationContext().registerSingleton(this);
+        }
     }
 
     /**

--- a/azure-function-http/src/test/groovy/io/micronaut/azure/function/http/ApplicationContextInitSpec.groovy
+++ b/azure-function-http/src/test/groovy/io/micronaut/azure/function/http/ApplicationContextInitSpec.groovy
@@ -1,0 +1,29 @@
+package io.micronaut.azure.function.http
+
+import spock.lang.Issue
+import spock.lang.Specification
+
+class ApplicationContextInitSpec extends Specification {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-azure/issues/688")
+    void "application context should be initialized only once"() {
+        given:
+        AzureHttpFunction function1 = new AzureHttpFunction()
+        Person person = new Person("John", 30)
+        function1.getApplicationContext().registerSingleton(person)
+
+        when:
+        AzureHttpFunction function2 = new AzureHttpFunction()
+        AzureHttpFunction function3 = new AzureHttpFunction()
+
+        then:
+        function1.getApplicationContext().getBeanDefinitions(Person.class).size() == 1
+        function2.getApplicationContext().getBeanDefinitions(Person.class).size() == 1
+        function3.getApplicationContext().getBeanDefinitions(Person.class).size() == 1
+
+        cleanup:
+        function1.close()
+        function2.close()
+        function3.close()
+    }
+}

--- a/azure-function-http/src/test/groovy/io/micronaut/azure/function/http/HttpHeaderConflictFunctionSpec.groovy
+++ b/azure-function-http/src/test/groovy/io/micronaut/azure/function/http/HttpHeaderConflictFunctionSpec.groovy
@@ -1,0 +1,34 @@
+package io.micronaut.azure.function.http
+
+import com.microsoft.azure.functions.HttpMethod
+import com.microsoft.azure.functions.HttpResponseMessage
+import io.micronaut.http.HttpStatus
+import spock.lang.Issue
+import spock.lang.Specification;
+
+class HttpHeaderConflictFunctionSpec extends Specification {
+
+    @Issue("https://github.com/micronaut-projects/micronaut-azure/issues/696")
+    void "verify Http header Transfer-Encoding is not return in context Azure Function"() {
+        given:
+        AzureHttpFunction function = new AzureHttpFunction()
+
+        when:
+        HttpResponseMessage responseMessage = retrieve(function)
+
+        then:
+        responseMessage.statusCode == HttpStatus.OK.code
+        responseMessage.body == 'Good job!'
+
+        and:
+        responseMessage.getHeader('Transfer-Encoding') == null
+
+        cleanup:
+        function.close()
+    }
+
+    private static HttpResponseMessage retrieve(AzureHttpFunction function) {
+        HttpRequestMessageBuilder<?> builder = function.request(HttpMethod.GET, "/headers/echo2")
+        builder.invoke()
+    }
+}

--- a/azure-function-http/src/test/java/io/micronaut/azure/function/http/HeadersController.java
+++ b/azure-function-http/src/test/java/io/micronaut/azure/function/http/HeadersController.java
@@ -2,6 +2,7 @@ package io.micronaut.azure.function.http;
 
 import io.micronaut.http.HttpHeaders;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
 import io.micronaut.http.MediaType;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
@@ -14,5 +15,11 @@ public class HeadersController {
     @Get("/echo")
     public String index(HttpRequest<?> request) {
         return "Accept: " + request.getHeaders().get(HttpHeaders.ACCEPT) + " Turbo-frame: " + request.getHeaders().get("Turbo-Frame");
+    }
+
+    @Produces(MediaType.TEXT_PLAIN)
+    @Get("/echo2")
+    public HttpResponse<String> index2(HttpRequest<?> request) {
+        return HttpResponse.ok("Good job!").header("Transfer-Encoding", "chunked");
     }
 }

--- a/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
+++ b/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
@@ -35,7 +35,7 @@ import java.io.Closeable;
 public abstract class AzureFunction implements ApplicationContextProvider, Closeable {
 
     protected static final Logger LOG = LoggerFactory.getLogger(AzureFunction.class);
-    protected ApplicationContext applicationContext;
+    protected static ApplicationContext applicationContext;
 
     /**
      * Default constructor.

--- a/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
+++ b/azure-function/src/main/java/io/micronaut/azure/function/AzureFunction.java
@@ -90,6 +90,11 @@ public abstract class AzureFunction implements ApplicationContextProvider, Close
         }
     }
 
+    /**
+     * Initializes the application context. The context manages bean definitions and resolves dependencies.
+     *
+     * @param applicationContextBuilder the builder used to construct the application context
+     */
     public void startApplicationContext(ApplicationContextBuilder applicationContextBuilder) {
         if (applicationContext == null) {
             applicationContext = (applicationContextBuilder != null ? applicationContextBuilder : defaultApplicationContextBuilder()).build();

--- a/test-suite-dockerised/src/main/java/example/micronaut/ReactiveController.java
+++ b/test-suite-dockerised/src/main/java/example/micronaut/ReactiveController.java
@@ -1,0 +1,27 @@
+package example.micronaut;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import org.reactivestreams.Publisher;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+@Controller("/reactive")
+public class ReactiveController {
+
+    @Produces(MediaType.TEXT_PLAIN)
+    @Get
+    public Publisher<String> reactive() {
+        Executor executor = Executors.newSingleThreadExecutor();
+        return (s) -> {
+            IntStream.range(0, 5).forEach(i -> CompletableFuture.supplyAsync(() -> String.valueOf(i), executor)
+                .thenAccept(s::onNext));
+            CompletableFuture.runAsync(s::onComplete, executor);
+        };
+    }
+}

--- a/test-suite-dockerised/src/test/groovy/example/micronaut/HeaderFunctionSpec.groovy
+++ b/test-suite-dockerised/src/test/groovy/example/micronaut/HeaderFunctionSpec.groovy
@@ -43,7 +43,7 @@ class HeaderFunctionSpec extends Specification {
         then:
         def response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
         response.statusCode() == 200
-        response.body() == '[0, 1, 2, 3, 4]'
+        response.body() == '01234'
 
         and:
         response.headers().allValues("Transfer-Encoding").size() == 1

--- a/test-suite-dockerised/src/test/groovy/example/micronaut/HeaderFunctionSpec.groovy
+++ b/test-suite-dockerised/src/test/groovy/example/micronaut/HeaderFunctionSpec.groovy
@@ -1,0 +1,62 @@
+package example.micronaut
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.MountableFile
+import spock.lang.AutoCleanup
+import spock.lang.Issue
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.util.environment.Jvm
+
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+@Issue("https://github.com/micronaut-projects/micronaut-azure/issues/696")
+class HeaderFunctionSpec extends Specification {
+
+    private static final String DOCKER_IMAGE_NAME = "mcr.microsoft.com/azure-functions/java:4-java${Jvm.current.javaSpecificationVersion}"
+
+    @Shared
+    @AutoCleanup
+    GenericContainer azureFunctionContainer = new GenericContainer(DOCKER_IMAGE_NAME)
+            .withEnv("AzureWebJobsScriptRoot", "/home/site/wwwroot")
+            .withEnv("AzureFunctionsJobHost__Logging__Console__IsEnabled", "true")
+            .withLogConsumer { log -> print("${log.getUtf8String()}") }
+            .withExposedPorts(80)
+            .waitingFor(Wait.forLogMessage(".*Host lock lease acquired by instance ID.*", 1))
+
+    def setupSpec() {
+        azureFunctionContainer
+                .tap { copyDirectory(it, new File("build/azure-functions/test-suite"), "/home/site/wwwroot") }
+                .start()
+    }
+
+    void "headers in Azure function context should not cause conflicts"() {
+        when:
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(new URI("http://localhost:${azureFunctionContainer.getMappedPort(80)}/reactive"))
+                .GET()
+                .build()
+
+        then:
+        def response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
+        response.statusCode() == 200
+        response.body() == '[0, 1, 2, 3, 4]'
+
+        and:
+        response.headers().allValues("Transfer-Encoding").size() == 1
+        response.headers().firstValue("Transfer-Encoding").get() == "chunked"
+    }
+
+    void copyDirectory(GenericContainer container, File dir, String root) {
+        println("Copying directory: ${dir.canonicalPath} to ${DOCKER_IMAGE_NAME}:$root")
+        dir.traverse { file ->
+            if (file.isFile()) {
+                println("Copying file: $file to $root${file.path.substring(dir.path.size())}")
+                container.withCopyFileToContainer(MountableFile.forHostPath(file.canonicalPath), root + file.path.substring(dir.path.size()))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Solution for the problem of the application context since it is being reset for each invocation of the function, and should be global for its life cycle. https://github.com/micronaut-projects/micronaut-azure/issues/688

A check is included to prevent create an AzureHttpFunction bean per execution.
