### PR TITLE
test with context

### DIFF
--- a/azure-tracing/src/test/java/io/micronaut/azure/tracing/AzureTracingConfigurationPropertiesTest.java
+++ b/azure-tracing/src/test/java/io/micronaut/azure/tracing/AzureTracingConfigurationPropertiesTest.java
@@ -1,9 +1,26 @@
 package io.micronaut.azure.tracing;
 
+import io.micronaut.context.ApplicationContext;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class AzureTracingConfigurationPropertiesTest {
+
+    @Test
+    void connectionStringCanBePopulatedViaConfiguration() {
+        Map<String, Object> config = Map.of(
+            "azure.tracing.connection-string", "foobar"
+        );
+        try (ApplicationContext ctx = ApplicationContext.run(config)) {
+
+            AzureTracingConfigurationProperties tracingConfig =
+                ctx.getBean(AzureTracingConfigurationProperties.class);
+            assertEquals("foobar", tracingConfig.getConnectionString());
+        }
+    }
 
     @Test
     void setterAndGetter() {


### PR DESCRIPTION
I don't understand the failure as I think the class is not in a compileOnly dependency 

https://github.com/micronaut-projects/micronaut-tracing/blob/7.1.x/tracing-opentelemetry/build.gradle

but this tests fails with: 

```
16:03:17.472 [main] INFO  i.m.c.DefaultApplicationContext$RuntimeConfiguredEnvironment - Established active environments: [test]

Failed to initialize the bean [class io.micronaut.tracing.opentelemetry.interceptor.NewSpanOpenTelemetryTraceInterceptor]: io/opentelemetry/instrumentation/api/incubator/semconv/util/ClassAndMethod
io.micronaut.context.exceptions.BeanInstantiationException: Failed to initialize the bean [class io.micronaut.tracing.opentelemetry.interceptor.NewSpanOpenTelemetryTraceInterceptor]: io/opentelemetry/instrumentation/api/incubator/semconv/util/ClassAndMethod
	at app//io.micronaut.context.AbstractInitializableBeanDefinitionAndReference.load(AbstractInitializableBeanDefinitionAndReference.java:131)
	at app//io.micronaut.context.DefaultBeanContext$BeanDefinitionProducer.getDefinitionIfEnabled(DefaultBeanContext.java:4389)
	at app//io.micronaut.context.DefaultBeanContext.collectBeanCandidates(DefaultBeanContext.java:2200)
	at app//io.micronaut.context.DefaultBeanContext.findBeanCandidates(DefaultBeanContext.java:2175)
	at app//io.micronaut.context.DefaultBeanContext.findBeanCandidatesInternal(DefaultBeanContext.java:3461)
	at app//io.micronaut.context.DefaultBeanContext.getBeanRegistrations(DefaultBeanContext.java:3517)
	at app//io.micronaut.context.AbstractBeanResolutionContext.getBeanRegistrations(AbstractBeanResolutionContext.java:316)
	at app//io.micronaut.context.AbstractInitializableBeanDefinition.resolveBeanRegistrations(AbstractInitializableBeanDefinition.java:2287)
	at app//io.micronaut.context.AbstractInitializableBeanDefinition.getBeanRegistrationsForConstructorArgument(AbstractInitializableBeanDefinition.java:1532)
	at app//io.micronaut.scheduling.processor.$ScheduledMethodProcessor$ApplicationEventListener$scheduleTasks1$Intercepted$Definition.instantiate(Unknown Source)
	at app//io.micronaut.context.DefaultBeanContext.resolveByBeanFactory(DefaultBeanContext.java:2337)
	at app//io.micronaut.context.DefaultBeanContext.createRegistration(DefaultBeanContext.java:3150)
	at app//io.micronaut.context.SingletonScope.getOrCreate(SingletonScope.java:80)
	at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistration(DefaultBeanContext.java:3000)
	at app//io.micronaut.context.DefaultBeanContext.addCandidateToList(DefaultBeanContext.java:3613)
	at app//io.micronaut.context.DefaultBeanContext.resolveBeanRegistrations(DefaultBeanContext.java:3568)
	at app//io.micronaut.context.DefaultBeanContext.getBeanRegistrations(DefaultBeanContext.java:3542)
	at app//io.micronaut.context.DefaultBeanContext.getBeansOfType(DefaultBeanContext.java:1475)
	at app//io.micronaut.context.DefaultBeanContext.getBeansOfType(DefaultBeanContext.java:896)
	at app//io.micronaut.context.DefaultBeanContext.getBeansOfType(DefaultBeanContext.java:886)
	at app//io.micronaut.context.event.ApplicationEventPublisherFactory$2.lambda$$1(ApplicationEventPublisherFactory.java:215)
	at app//io.micronaut.core.util.SupplierUtil$1.get(SupplierUtil.java:47)
	at app//io.micronaut.context.event.ApplicationEventPublisherFactory$2.publishEvent(ApplicationEventPublisherFactory.java:226)
	at app//io.micronaut.context.DefaultBeanContext.publishEvent(DefaultBeanContext.java:1867)
	at app//io.micronaut.context.DefaultBeanContext.start(DefaultBeanContext.java:368)
	at app//io.micronaut.context.DefaultApplicationContext.start(DefaultApplicationContext.java:225)
	at app//io.micronaut.context.ApplicationContextBuilder.start(ApplicationContextBuilder.java:332)
	at app//io.micronaut.context.ApplicationContext.run(ApplicationContext.java:173)
	at app//io.micronaut.context.ApplicationContext.run(ApplicationContext.java:155)
	at app//io.micronaut.azure.tracing.AzureTracingConfigurationPropertiesTest.connectionStringCanBePopulatedViaConfiguration(AzureTracingConfigurationPropertiesTest.java:17)
	at java.base@21.0.7/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base@21.0.7/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base@21.0.7/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: java.lang.NoClassDefFoundError: io/opentelemetry/instrumentation/api/incubator/semconv/util/ClassAndMethod
	at app//io.micronaut.tracing.opentelemetry.interceptor.$NewSpanOpenTelemetryTraceInterceptor$Definition.<clinit>(Unknown Source)
	at java.base@21.0.7/jdk.internal.misc.Unsafe.allocateInstance(Native Method)
	at java.base@21.0.7/java.lang.invoke.DirectMethodHandle.allocateInstance(DirectMethodHandle.java:501)
	at app//io.micronaut.core.io.service.MicronautMetaServiceLoaderUtils.instantiate(MicronautMetaServiceLoaderUtils.java:190)
	at app//io.micronaut.core.io.service.MicronautMetaServiceLoaderUtils$ServiceInstanceLoader.compute(MicronautMetaServiceLoaderUtils.java:298)
	at java.base@21.0.7/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
	at java.base@21.0.7/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base@21.0.7/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1310)
	at java.base@21.0.7/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1841)
	at java.base@21.0.7/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base@21.0.7/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: java.lang.ClassNotFoundException: io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod
	at java.base@21.0.7/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base@21.0.7/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base@21.0.7/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 11 more


io/opentelemetry/instrumentation/api/incubator/semconv/util/ClassAndMethod
java.lang.NoClassDefFoundError: io/opentelemetry/instrumentation/api/incubator/semconv/util/ClassAndMethod
	at app//io.micronaut.tracing.opentelemetry.interceptor.$NewSpanOpenTelemetryTraceInterceptor$Definition.<clinit>(Unknown Source)
	at java.base@21.0.7/jdk.internal.misc.Unsafe.allocateInstance(Native Method)
	at java.base@21.0.7/java.lang.invoke.DirectMethodHandle.allocateInstance(DirectMethodHandle.java:501)
	at app//io.micronaut.core.io.service.MicronautMetaServiceLoaderUtils.instantiate(MicronautMetaServiceLoaderUtils.java:190)
	at app//io.micronaut.core.io.service.MicronautMetaServiceLoaderUtils$ServiceInstanceLoader.compute(MicronautMetaServiceLoaderUtils.java:298)
	at java.base@21.0.7/java.util.concurrent.RecursiveAction.exec(RecursiveAction.java:194)
	at java.base@21.0.7/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base@21.0.7/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1310)
	at java.base@21.0.7/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1841)
	at java.base@21.0.7/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1806)
	at java.base@21.0.7/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: java.lang.ClassNotFoundException: io.opentelemetry.instrumentation.api.incubator.semconv.util.ClassAndMethod
	at java.base@21.0.7/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base@21.0.7/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base@21.0.7/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
	... 11 more

```