### PR TITLE
Add Azure Key Vault Signing

### DIFF
--- a/azure-secret-manager/build.gradle.kts
+++ b/azure-secret-manager/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     api(projects.micronautAzureSdk)
     api(libs.azure.identity)
     api(libs.azure.security.keyvault.secrets)
+    api(libs.azure.security.keyvault.keys)
 
     implementation(mn.micronaut.discovery.core)
     implementation(mnReactor.micronaut.reactor)
@@ -19,4 +20,3 @@ dependencies {
     testCompileOnly(mn.micronaut.inject.groovy)
     testImplementation(mn.micronaut.http.client)
 }
-

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/client/DefaultKeyVaultSigningClient.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/client/DefaultKeyVaultSigningClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ import java.util.Map;
  *
  * <p>Maintains a bounded LRU cache of {@link CryptographyClient} instances to avoid
  * creating a new client for every signing operation while preventing unbounded memory growth.</p>
+ *
+ * @since 5.13.0
  */
 @Singleton
 @BootstrapContextCompatible

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/client/DefaultKeyVaultSigningClient.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/client/DefaultKeyVaultSigningClient.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.azure.secretmanager.client;
+
+import com.azure.core.credential.TokenCredential;
+import com.azure.security.keyvault.keys.cryptography.CryptographyClient;
+import com.azure.security.keyvault.keys.cryptography.CryptographyClientBuilder;
+import com.azure.security.keyvault.keys.cryptography.models.SignResult;
+import com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm;
+import io.micronaut.azure.secretmanager.configuration.AzureKeyVaultConfigurationProperties;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Default implementation that delegates to {@link CryptographyClient}.
+ *
+ * <p>Maintains a bounded LRU cache of {@link CryptographyClient} instances to avoid
+ * creating a new client for every signing operation while preventing unbounded memory growth.</p>
+ */
+@Singleton
+@BootstrapContextCompatible
+@Requires(classes = CryptographyClient.class)
+@Requires(property = AzureKeyVaultConfigurationProperties.PREFIX + ".keys.enabled", value = StringUtils.TRUE)
+@Requires(property = AzureKeyVaultConfigurationProperties.PREFIX + ".keys.signing.enabled", value = StringUtils.TRUE)
+public class DefaultKeyVaultSigningClient implements KeyVaultSigningClient {
+
+    private static final int MAX_CACHED_CLIENTS = 100;
+
+    private final TokenCredential tokenCredential;
+    private final Map<String, CryptographyClient> clients;
+
+    /**
+     * @param tokenCredential Azure token credentials
+     */
+    public DefaultKeyVaultSigningClient(TokenCredential tokenCredential) {
+        this.tokenCredential = tokenCredential;
+        // Bounded LRU cache - removes eldest entry when size exceeds MAX_CACHED_CLIENTS
+        this.clients = new LinkedHashMap<>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, CryptographyClient> eldest) {
+                return size() > MAX_CACHED_CLIENTS;
+            }
+        };
+    }
+
+    @Override
+    public byte[] sign(@NonNull String keyId, @NonNull SignatureAlgorithm algorithm, @NonNull byte[] data) {
+        ArgumentUtils.requireNonNull("keyId", keyId);
+        ArgumentUtils.requireNonNull("algorithm", algorithm);
+        ArgumentUtils.requireNonNull("data", data);
+        if (StringUtils.isEmpty(keyId)) {
+            throw new IllegalArgumentException("keyId cannot be blank");
+        }
+
+        CryptographyClient client = getOrCreateClient(keyId);
+        SignResult result = client.signData(algorithm, data);
+        return result.getSignature();
+    }
+
+    private synchronized CryptographyClient getOrCreateClient(String keyId) {
+        return clients.computeIfAbsent(keyId, this::buildClient);
+    }
+
+    private CryptographyClient buildClient(String keyId) {
+        return new CryptographyClientBuilder()
+                .keyIdentifier(keyId)
+                .credential(tokenCredential)
+                .buildClient();
+    }
+}

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/client/KeyVaultSigningClient.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/client/KeyVaultSigningClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import io.micronaut.core.annotation.NonNull;
 
 /**
  * Abstraction for performing signing operations with Azure Key Vault.
+ *
+ * @since 5.13.0
  */
 public interface KeyVaultSigningClient {
 

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/client/KeyVaultSigningClient.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/client/KeyVaultSigningClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.azure.secretmanager.client;
+
+import com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm;
+import io.micronaut.core.annotation.NonNull;
+
+/**
+ * Abstraction for performing signing operations with Azure Key Vault.
+ */
+public interface KeyVaultSigningClient {
+
+    /**
+     * Sign the given data using the key identified by {@code keyId}.
+     *
+     * @param keyId     the full key identifier
+     * @param algorithm the signature algorithm
+     * @param data      the data to sign
+     * @return the signature bytes
+     */
+    @NonNull
+    byte[] sign(@NonNull String keyId, @NonNull SignatureAlgorithm algorithm, @NonNull byte[] data);
+}

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/configuration/AzureKeyVaultConfigurationProperties.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/configuration/AzureKeyVaultConfigurationProperties.java
@@ -30,6 +30,7 @@ public class AzureKeyVaultConfigurationProperties {
     public static final String PREFIX = Environment.AZURE + ".key-vault";
 
     private String vaultURL;
+    private KeysConfiguration keys = new KeysConfiguration();
 
     /**
      * @return key vault url.
@@ -45,4 +46,100 @@ public class AzureKeyVaultConfigurationProperties {
         this.vaultURL = vaultURL;
     }
 
+    /**
+     * @return key specific configuration.
+     */
+    public KeysConfiguration getKeys() {
+        return keys;
+    }
+
+    /**
+     * @param keys key specific configuration.
+     */
+    public void setKeys(KeysConfiguration keys) {
+        if (keys != null) {
+            this.keys = keys;
+        }
+    }
+
+    /**
+     * Configuration for interacting with Key Vault keys.
+     */
+    @ConfigurationProperties("keys")
+    @BootstrapContextCompatible
+    public static class KeysConfiguration {
+        public static final boolean DEFAULT_ENABLED = false;
+
+        private boolean enabled = DEFAULT_ENABLED;
+        private SigningConfiguration signing = new SigningConfiguration();
+
+        /**
+         * @return true if the key configuration client should be enabled.
+         */
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        /**
+         * @param enabled enable or disable the key configuration client.
+         */
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        /**
+         * @return signing configuration.
+         */
+        public SigningConfiguration getSigning() {
+            return signing;
+        }
+
+        /**
+         * @param signing signing configuration.
+         */
+        public void setSigning(SigningConfiguration signing) {
+            if (signing != null) {
+                this.signing = signing;
+            }
+        }
+
+        /**
+         * Configuration specific to signing operations.
+         */
+        @ConfigurationProperties("signing")
+        @BootstrapContextCompatible
+        public static class SigningConfiguration {
+
+            private boolean enabled;
+            private String defaultAlgorithm;
+
+            /**
+             * @return true if signing support is enabled.
+             */
+            public boolean isEnabled() {
+                return enabled;
+            }
+
+            /**
+             * @param enabled enable or disable signing support.
+             */
+            public void setEnabled(boolean enabled) {
+                this.enabled = enabled;
+            }
+
+            /**
+             * @return the default signature algorithm (e.g. RS256).
+             */
+            public String getDefaultAlgorithm() {
+                return defaultAlgorithm;
+            }
+
+            /**
+             * @param defaultAlgorithm default algorithm (e.g. RS256).
+             */
+            public void setDefaultAlgorithm(String defaultAlgorithm) {
+                this.defaultAlgorithm = defaultAlgorithm;
+            }
+        }
+    }
 }

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/configuration/AzureKeyVaultConfigurationProperties.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/configuration/AzureKeyVaultConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ public class AzureKeyVaultConfigurationProperties {
 
     /**
      * @return key specific configuration.
+     * @since 5.13.0
      */
     public KeysConfiguration getKeys() {
         return keys;
@@ -55,6 +56,7 @@ public class AzureKeyVaultConfigurationProperties {
 
     /**
      * @param keys key specific configuration.
+     * @since 5.13.0
      */
     public void setKeys(KeysConfiguration keys) {
         if (keys != null) {
@@ -64,6 +66,8 @@ public class AzureKeyVaultConfigurationProperties {
 
     /**
      * Configuration for interacting with Key Vault keys.
+     *
+     * @since 5.13.0
      */
     @ConfigurationProperties("keys")
     @BootstrapContextCompatible
@@ -105,6 +109,8 @@ public class AzureKeyVaultConfigurationProperties {
 
         /**
          * Configuration specific to signing operations.
+         *
+         * @since 5.13.0
          */
         @ConfigurationProperties("signing")
         @BootstrapContextCompatible

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/signing/DefaultKeyVaultKeySigner.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/signing/DefaultKeyVaultKeySigner.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.azure.secretmanager.signing;
+
+import com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm;
+import io.micronaut.azure.secretmanager.client.KeyVaultSigningClient;
+import io.micronaut.azure.secretmanager.configuration.AzureKeyVaultConfigurationProperties;
+import io.micronaut.context.annotation.BootstrapContextCompatible;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.util.ArgumentUtils;
+import io.micronaut.core.util.StringUtils;
+import jakarta.inject.Singleton;
+
+/**
+ * Default implementation of {@link KeyVaultKeySigner}.
+ *
+ * <p>Constructs key identifiers from the configured vault URL and key name,
+ * delegating the actual signing operation to Azure Key Vault via {@link KeyVaultSigningClient}.</p>
+ */
+@Singleton
+@BootstrapContextCompatible
+@Requires(beans = KeyVaultSigningClient.class)
+@Requires(property = AzureKeyVaultConfigurationProperties.PREFIX + ".keys.enabled", value = StringUtils.TRUE)
+@Requires(property = AzureKeyVaultConfigurationProperties.PREFIX + ".keys.signing.enabled", value = StringUtils.TRUE)
+public class DefaultKeyVaultKeySigner implements KeyVaultKeySigner {
+
+    private final KeyVaultSigningClient keyVaultSigningClient;
+    private final AzureKeyVaultConfigurationProperties configurationProperties;
+    private final String vaultUrl;
+
+    /**
+     * @param keyVaultSigningClient    Signing client abstraction
+     * @param configurationProperties  Configuration properties
+     */
+    public DefaultKeyVaultKeySigner(
+            KeyVaultSigningClient keyVaultSigningClient,
+            AzureKeyVaultConfigurationProperties configurationProperties
+    ) {
+        this.keyVaultSigningClient = keyVaultSigningClient;
+        this.configurationProperties = configurationProperties;
+        this.vaultUrl = normalizeVaultUrl(configurationProperties.getVaultURL());
+    }
+
+    @Override
+    public byte[] sign(@NonNull String keyName, @NonNull SignatureAlgorithm algorithm, @NonNull byte[] data) {
+        ArgumentUtils.requireNonNull("keyName", keyName);
+        ArgumentUtils.requireNonNull("algorithm", algorithm);
+        ArgumentUtils.requireNonNull("data", data);
+        if (StringUtils.isEmpty(keyName)) {
+            throw new IllegalArgumentException("keyName cannot be blank");
+        }
+        String keyId = buildKeyId(keyName);
+        return keyVaultSigningClient.sign(keyId, algorithm, data);
+    }
+
+    @Override
+    public byte[] sign(@NonNull String keyName, @NonNull byte[] data) {
+        SignatureAlgorithm algorithm = resolveDefaultAlgorithm();
+        if (algorithm == null) {
+            throw new IllegalStateException(
+                "No default signing algorithm configured. " +
+                "Specify azure.key-vault.keys.signing.default-algorithm or provide an algorithm explicitly."
+            );
+        }
+        return sign(keyName, algorithm, data);
+    }
+
+    /**
+     * Builds a key identifier URL from the vault URL and key name.
+     * Key Vault key identifiers follow the pattern: {vaultUrl}/keys/{keyName}
+     *
+     * @param keyName the key name
+     * @return the full key identifier URL
+     */
+    private String buildKeyId(String keyName) {
+        return vaultUrl + "/keys/" + keyName;
+    }
+
+    private String normalizeVaultUrl(String url) {
+        if (url == null) {
+            throw new IllegalStateException("Vault URL must be configured via azure.key-vault.vault-url");
+        }
+        return url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+    }
+
+    private SignatureAlgorithm resolveDefaultAlgorithm() {
+        String configured = configurationProperties.getKeys().getSigning().getDefaultAlgorithm();
+        if (StringUtils.isEmpty(configured)) {
+            return null;
+        }
+        return SignatureAlgorithm.fromString(configured);
+    }
+}

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/signing/DefaultKeyVaultKeySigner.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/signing/DefaultKeyVaultKeySigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ import jakarta.inject.Singleton;
  *
  * <p>Constructs key identifiers from the configured vault URL and key name,
  * delegating the actual signing operation to Azure Key Vault via {@link KeyVaultSigningClient}.</p>
+ *
+ * @since 5.13.0
  */
 @Singleton
 @BootstrapContextCompatible

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/signing/KeyVaultKeySigner.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/signing/KeyVaultKeySigner.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017-2020 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.micronaut.azure.secretmanager.signing;
+
+import com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm;
+import io.micronaut.core.annotation.NonNull;
+
+/**
+ * Service for signing payloads with Azure Key Vault keys.
+ */
+public interface KeyVaultKeySigner {
+
+    /**
+     * Sign the supplied data with the provided key using the specified algorithm.
+     *
+     * @param keyName   the key name
+     * @param algorithm the signature algorithm
+     * @param data      the data to sign
+     * @return the signature bytes
+     */
+    @NonNull
+    byte[] sign(@NonNull String keyName, @NonNull SignatureAlgorithm algorithm, @NonNull byte[] data);
+
+    /**
+     * Sign the supplied data with the provided key using the default algorithm configured for signing.
+     *
+     * @param keyName the key name
+     * @param data    the data to sign
+     * @return the signature bytes
+     */
+    @NonNull
+    byte[] sign(@NonNull String keyName, @NonNull byte[] data);
+}

--- a/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/signing/KeyVaultKeySigner.java
+++ b/azure-secret-manager/src/main/java/io/micronaut/azure/secretmanager/signing/KeyVaultKeySigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 original authors
+ * Copyright 2017-2026 original authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import io.micronaut.core.annotation.NonNull;
 
 /**
  * Service for signing payloads with Azure Key Vault keys.
+ *
+ * @since 5.13.0
  */
 public interface KeyVaultKeySigner {
 

--- a/azure-secret-manager/src/test/groovy/io/micronaut/azure/secretmanager/AzureKeyVaultKeySignerSpec.groovy
+++ b/azure-secret-manager/src/test/groovy/io/micronaut/azure/secretmanager/AzureKeyVaultKeySignerSpec.groovy
@@ -1,0 +1,148 @@
+package io.micronaut.azure.secretmanager
+
+import com.azure.security.keyvault.keys.cryptography.models.SignatureAlgorithm
+import io.micronaut.azure.secretmanager.client.DefaultKeyVaultSigningClient
+import io.micronaut.azure.secretmanager.client.KeyVaultSigningClient
+import io.micronaut.azure.secretmanager.signing.KeyVaultKeySigner
+import io.micronaut.context.ApplicationContext
+import io.micronaut.context.annotation.BootstrapContextCompatible
+import io.micronaut.context.annotation.Replaces
+import io.micronaut.context.annotation.Requires
+import jakarta.inject.Singleton
+import spock.lang.Specification
+
+class AzureKeyVaultKeySignerSpec extends Specification {
+
+    void "it signs payloads using provided algorithm"() {
+        given:
+        byte[] payload = "payload".bytes
+        MockKeyVaultSigningClient.signature = "signed".bytes
+        MockKeyVaultSigningClient.reset()
+
+        ApplicationContext ctx = ApplicationContext.run([
+                'spec.name'                                      : 'azure-key-signing',
+                'azure.key-vault.vault-url'                      : 'https://example-vault.vault.azure.net',
+                'azure.key-vault.keys.enabled'                   : true,
+                'azure.key-vault.keys.signing.enabled'           : true,
+                'azure.key-vault.keys.signing.default-algorithm' : 'RS256'
+        ])
+        KeyVaultKeySigner signer = ctx.getBean(KeyVaultKeySigner)
+
+        when:
+        byte[] signature = signer.sign('sample-key', SignatureAlgorithm.RS256, payload)
+
+        then:
+        signature == MockKeyVaultSigningClient.signature
+        MockKeyVaultSigningClient.lastKeyId == 'https://example-vault.vault.azure.net/keys/sample-key'
+        MockKeyVaultSigningClient.lastAlgorithm == SignatureAlgorithm.RS256
+        MockKeyVaultSigningClient.lastPayload == payload
+
+        cleanup:
+        ctx.close()
+        MockKeyVaultSigningClient.reset()
+    }
+
+    void "it signs payloads using default algorithm"() {
+        given:
+        byte[] payload = "payload".bytes
+        MockKeyVaultSigningClient.signature = "signed".bytes
+        MockKeyVaultSigningClient.reset()
+
+        ApplicationContext ctx = ApplicationContext.run([
+                'spec.name'                                      : 'azure-key-signing',
+                'azure.key-vault.vault-url'                      : 'https://example-vault.vault.azure.net',
+                'azure.key-vault.keys.enabled'                   : true,
+                'azure.key-vault.keys.signing.enabled'           : true,
+                'azure.key-vault.keys.signing.default-algorithm' : 'RS256'
+        ])
+        KeyVaultKeySigner signer = ctx.getBean(KeyVaultKeySigner)
+
+        when:
+        byte[] signature = signer.sign('my-key', payload)
+
+        then:
+        signature == MockKeyVaultSigningClient.signature
+        MockKeyVaultSigningClient.lastKeyId == 'https://example-vault.vault.azure.net/keys/my-key'
+        MockKeyVaultSigningClient.lastAlgorithm == SignatureAlgorithm.RS256
+
+        cleanup:
+        ctx.close()
+        MockKeyVaultSigningClient.reset()
+    }
+
+    void "it requires a default algorithm when none supplied"() {
+        given:
+        MockKeyVaultSigningClient.signature = "signed".bytes
+        MockKeyVaultSigningClient.reset()
+
+        ApplicationContext ctx = ApplicationContext.run([
+                'spec.name'                            : 'azure-key-signing',
+                'azure.key-vault.vault-url'            : 'https://example-vault.vault.azure.net',
+                'azure.key-vault.keys.enabled'         : true,
+                'azure.key-vault.keys.signing.enabled' : true
+        ])
+        KeyVaultKeySigner signer = ctx.getBean(KeyVaultKeySigner)
+
+        when:
+        signer.sign('sample-key', "payload".bytes)
+
+        then:
+        thrown IllegalStateException
+
+        cleanup:
+        ctx.close()
+        MockKeyVaultSigningClient.reset()
+    }
+
+    void "it normalizes vault URL with trailing slash"() {
+        given:
+        byte[] payload = "payload".bytes
+        MockKeyVaultSigningClient.signature = "signed".bytes
+        MockKeyVaultSigningClient.reset()
+
+        ApplicationContext ctx = ApplicationContext.run([
+                'spec.name'                                      : 'azure-key-signing',
+                'azure.key-vault.vault-url'                      : 'https://example-vault.vault.azure.net/',
+                'azure.key-vault.keys.enabled'                   : true,
+                'azure.key-vault.keys.signing.enabled'           : true,
+                'azure.key-vault.keys.signing.default-algorithm' : 'RS256'
+        ])
+        KeyVaultKeySigner signer = ctx.getBean(KeyVaultKeySigner)
+
+        when:
+        signer.sign('my-key', SignatureAlgorithm.RS256, payload)
+
+        then:
+        MockKeyVaultSigningClient.lastKeyId == 'https://example-vault.vault.azure.net/keys/my-key'
+
+        cleanup:
+        ctx.close()
+        MockKeyVaultSigningClient.reset()
+    }
+
+    @Singleton
+    @Replaces(DefaultKeyVaultSigningClient)
+    @BootstrapContextCompatible
+    @Requires(property = 'spec.name', value = 'azure-key-signing')
+    static class MockKeyVaultSigningClient implements KeyVaultSigningClient {
+
+        static byte[] signature = "signed".bytes
+        static String lastKeyId
+        static SignatureAlgorithm lastAlgorithm
+        static byte[] lastPayload
+
+        static void reset() {
+            lastKeyId = null
+            lastAlgorithm = null
+            lastPayload = null
+        }
+
+        @Override
+        byte[] sign(String keyId, SignatureAlgorithm algorithm, byte[] data) {
+            lastKeyId = keyId
+            lastAlgorithm = algorithm
+            lastPayload = data
+            return signature
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ managed-opentelemetry-autoconfigure = { module = "com.azure:azure-monitor-opente
 commons-codec = { module = "commons-codec:commons-codec", version.ref = "commons-codec" }
 azure-identity = { module = "com.azure:azure-identity" }
 azure-security-keyvault-secrets = { module = "com.azure:azure-security-keyvault-secrets" }
+azure-security-keyvault-keys = { module = "com.azure:azure-security-keyvault-keys" }
 azure-storage-common = { module = "com.azure:azure-storage-common" }
 azure-storage-blob = { module = "com.azure:azure-storage-blob" }
 azure-monitor-ingestion = { module = 'com.azure:azure-monitor-ingestion' }

--- a/src/main/docs/guide/azureKeyVault.adoc
+++ b/src/main/docs/guide/azureKeyVault.adoc
@@ -8,3 +8,48 @@ dependency:micronaut-discovery-client[groupId="io.micronaut.discovery"]
 NOTE: Azure doesn't allow _ and . in name of the secrets so the secret with name SECRET-ONE can be resolved also with SECRET_ONE and SECRET.ONE
 
 TIP: See the guide for https://guides.micronaut.io/latest/micronaut-cloud-secrets-azure.html[Securely store Micronaut application secrets in Azure Key Vault] to learn more.
+
+== Signing with Key Vault Keys
+
+Azure Key Vault can store cryptographic keys and perform signing operations without ever exposing the private key material. This is ideal for signing JWTs, assertions, or other payloads where you want the private key to remain secured in the vault.
+
+To enable signing with Key Vault keys:
+
+[configuration]
+----
+azure:
+  key-vault:
+    vault-url: https://your-vault.vault.azure.net
+    keys:
+      enabled: true
+      signing:
+        enabled: true
+        default-algorithm: RS256
+----
+
+The `KeyVaultKeySigner` bean lets you sign arbitrary payloads:
+
+[source,java]
+----
+@Singleton
+class JwtSigner {
+    private final KeyVaultKeySigner signer;
+
+    JwtSigner(KeyVaultKeySigner signer) {
+        this.signer = signer;
+    }
+
+    byte[] sign(byte[] payload) {
+        return signer.sign("jwt-signing-key", payload); // uses default algorithm
+    }
+}
+----
+
+If you need to override the algorithm per call, use the overloaded method:
+
+[source,java]
+----
+byte[] signature = signer.sign("jwt-signing-key", SignatureAlgorithm.RS256, payload);
+----
+
+Supported algorithms include RS256, RS384, RS512, PS256, PS384, PS512, ES256, ES384, and ES512, depending on your key type.

--- a/src/main/docs/guide/azureKeyVault/distributedConfiguration.adoc
+++ b/src/main/docs/guide/azureKeyVault/distributedConfiguration.adoc
@@ -22,3 +22,5 @@ image::key_vault_url.png[Key Vault URL]
 
 IMPORTANT: Make sure you have configured the correct credentials on your project following the <<azureSdk, Setting up Azure SDK >> section.
 And that the service account you designated your application has proper rights to read secrets. Follow the official link:https://docs.microsoft.com/en-us/azure/key-vault/general/rbac-guide?tabs=azure-cli[Access Control] guide for Azure Key Vault if you need more information.
+
+To enable Key Vault key signing support (for example, to sign JWT assertions without exposing private key material), see the "Signing with Key Vault Keys" section.


### PR DESCRIPTION
Closes #903.

Please let me know if this should be targeting 6.x or 5.12.x and I can rebase. 

Noting that the package is currently called `secretmanager` rather than `keyvault`, so naming might not be ideal right now.

This pull request introduces Azure Key Vault key signing support to the `azure-secret-manager` module. It adds new abstractions and implementations for signing payloads using Azure Key Vault keys, updates configuration to enable and customise signing, and provides comprehensive tests for the new functionality.

## Configuration Enhancements

* Extended `AzureKeyVaultConfigurationProperties` to support key-specific configuration, including enabling/disabling key support and setting default signing algorithms. [[1]](diffhunk://#diff-02eb150217067c6ba430509b9fceff3a2a52342ca2d36c28ab2f55c7fce7ac6dR33) [[2]](diffhunk://#diff-02eb150217067c6ba430509b9fceff3a2a52342ca2d36c28ab2f55c7fce7ac6dR49-R144)

## Dependency Updates

* Added `azure.security.keyvault.keys` library to dependencies for key signing support.
