### PR TITLE
Update to Micronaut Core 5.0.0-M22

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ commons-codec = "1.19.0"
 
 # Micronaut
 micronaut-platform = "4.10.8"
-micronaut = "5.0.0-M12"
+micronaut = "5.0.0-M22"
 micronaut-logging = "2.0.0-M2"
 micronaut-reactor = "4.0.0-M1"
 micronaut-serde = "3.0.0-M2"

--- a/test-suite-http-server-tck-azure-function-http-test/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpTestHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-azure-function-http-test/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpTestHttpServerTestSuite.java
@@ -8,7 +8,8 @@ import org.junit.platform.suite.api.SuiteDisplayName;
 @Suite
 @ExcludeClassNamePatterns({
     "io.micronaut.http.server.tck.tests.FilterProxyTest",
-    "io.micronaut.http.server.tck.tests.forms.UploadTest"
+    "io.micronaut.http.server.tck.tests.forms.UploadTest",
+    "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest"
 })
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Azure Functions HTTP Test")

--- a/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
+++ b/test-suite-http-server-tck-azure-function-http/src/test/java/io/micronaut/http/server/tck/azurehttpfunction/tests/AzureFunctionHttpHttpServerTestSuite.java
@@ -7,7 +7,8 @@ import org.junit.platform.suite.api.*;
         "io.micronaut.http.server.tck.tests.FilterProxyTest",
     "io.micronaut.http.server.tck.tests.ErrorHandlerFluxTest", // test fails testErrorHandlerWithFluxChunkedSignaledDelayedError
     "io.micronaut.http.server.tck.tests.forms.FormsJacksonAnnotationsTest", // test fails httpClientFormSubmissionsDoesNotSupportJacksonAnnotations"
-    "io.micronaut.http.server.tck.tests.forms.UploadTest"
+    "io.micronaut.http.server.tck.tests.forms.UploadTest",
+    "io.micronaut.http.server.tck.tests.forms.FormBindingDeadlockTest"
 })
 @SelectPackages("io.micronaut.http.server.tck.tests")
 @SuiteDisplayName("HTTP Server TCK for Azure Functions")


### PR DESCRIPTION
This updates the Micronaut Core version on the `6.0.x` maintenance line from `5.0.0-M12` to `5.0.0-M22`.

It also aligns the Azure HTTP test suite with the analogous Micronaut GCP adjustment by excluding `FormBindingDeadlockTest` in the HTTP test suite.

Validation:
- `./gradlew :test-suite-http-server-tck-azure-function-http-test:test --stacktrace`
- `./gradlew check -q -x japiCmp -x checkVersionCatalogCompatibility`
