### PR TITLE
Fix typo in configuration imports section

### DIFF
--- a/src/main/docs/guide/azureKeyVault/distributedConfiguration.adoc
+++ b/src/main/docs/guide/azureKeyVault/distributedConfiguration.adoc
@@ -34,7 +34,7 @@ As an alternative to the connection-string form, the importer also supports the 
 ----
 micronaut:
   config:
-    import:
+    imports:
       - provider: azure-key-vault
         name: contoso-vault2
         credential-mode: client-secret


### PR DESCRIPTION
Provider-name map syntax uses `imports` keyword instead of `import`.